### PR TITLE
fix(ci): Print test output on failure + add diagnostic logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,11 @@ jobs:
           chmod +x ~/.local/bin/bobnet
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           
+      - name: Verify bobnet installation
+        run: |
+          echo "PATH: $PATH"
+          echo "which bobnet: $(which bobnet || echo 'not found')"
+          bobnet --version || echo "bobnet command failed with exit code $?"
+          
       - name: Run test suite
         run: ./tests/run-all.sh

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -84,9 +84,8 @@ for script in "${TEST_SCRIPTS[@]}"; do
         else
             FAILED_SUITES=$((FAILED_SUITES + 1))
             TOTAL_TESTS=$((TOTAL_TESTS + 6))
+            echo "$OUTPUT"  # Print BEFORE error() exits
             error "$script failed"
-            echo "$OUTPUT"
-            exit 1
         fi
     fi
     


### PR DESCRIPTION
## Problem

CI tests fail with no output, making it impossible to diagnose the root cause.

## Changes

1. Fixed test runner: Moved test output print BEFORE error call
2. Added CI diagnostics: New verification step shows PATH, bobnet location, and version before running tests

## Testing

This PR will reveal the actual test failure in CI logs.